### PR TITLE
chore: add funding config for the repo Sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,18 @@
+# Funding sources shown in the "Sponsor" button on the repository page.
+#
+# These keys take a bare username, not a full URL:
+#     ko_fi: <username> → https://ko-fi.com/<username>
+#
+# Docs: https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+
+# Monthly or one-time, custom amounts.
+github: [agusgonzaleznic]
+
+# One-off: https://ko-fi.com/agusgonzaleznic
+#
+# A note for anyone checking this link: Ko-fi sits behind Cloudflare and answers
+# automated requests with a challenge page, so curl reports HTTP 403 for every
+# Ko-fi URL, real or invented. Verify it in a browser. A 403 proves nothing.
+ko_fi: agusgonzaleznic
+
+custom: ["https://agusgonzaleznic.com"]


### PR DESCRIPTION
Adds `.github/FUNDING.yml` so this repo shows a **Sponsor** button.

Without this file the button is hidden, even though the Sponsors listing at
https://github.com/sponsors/agusgonzaleznic is live and public.

Content matches the already-working file in `german-driving-school`:
`github` + `buy_me_a_coffee` (bare usernames, not URLs) and `custom` pointing
at agusgonzaleznic.com.